### PR TITLE
Add interface option to list in README

### DIFF
--- a/README
+++ b/README
@@ -25,6 +25,7 @@ Hardware:
     sudo ./vap11g.py
 * USAGE:
     options:
+    -i network interface (e.g. eth0, eth1, p4p1)
     -d debug mode
     -v verbose mode (more verbose than debug, with packet inspection)
     -c channel number to be set (NOT the channel on which the device should scan)

--- a/vap11g.py
+++ b/vap11g.py
@@ -348,7 +348,7 @@ def main():
     global debug,defaultInterface,verbose
     parser=OptionParser()
     parser.add_option("-i","--interface",dest="interface",help="destination LAN (ethernet) "+\
-            "interface (e.g. eth0, eth1)",metavar="interface")
+            "interface (e.g. eth0, eth1, p4p1)",metavar="interface")
     parser.add_option("-d","--debug",action="store_true",default=debug,dest="debug",
             help="debug mode switch",metavar="debug")
     parser.add_option("-v","--verbose",action="store_true",default=debug,dest="verbose",


### PR DESCRIPTION
Really useful option not currently documented in the README.
I was going to add it to the script, until I realised it was there and being silent!
I have also added 'p4p1' to the example list as this is the default interface for many Fedora installations; that is what led me to make this change.